### PR TITLE
大佬，发现您的项目引入了org.apache.thrift:libthrift@0.9.1组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,7 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.meituan.octo</groupId>
@@ -40,7 +37,7 @@
 
         <commons-lang3>3.7</commons-lang3>
         <netty.version>4.1.25.Final</netty.version>
-        <libthrift.version>0.9.3</libthrift.version>
+        <libthrift.version>0.14.0</libthrift.version>
         <snappy.version>1.1.1.6</snappy.version>
         <swift.version>0.16.0</swift.version>
         <junit.version>4.10</junit.version>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache Thrift Java client library授权问题漏洞
缺陷组件：org.apache.thrift:libthrift@0.9.1
漏洞编号：CVE-2018-1320
漏洞描述：Apache Thrift是美国阿帕奇（Apache）软件基金会的一个用于跨平台开发的框架。Java client library是其中的一个客户端库。
Apache Thrift Java client library0.5.0版本至0.11.0版本中存在授权问题漏洞，攻击者可利用该漏洞绕过安全检测。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2019-00640
影响范围：[0.6.1, 0.12.0)
最小修复版本：0.14.0
缺陷组件引入路径：com.meituan.octo:dorado-core-default@1.0.0->com.facebook.swift:swift-codec@0.16.0->org.apache.thrift:libthrift@0.9.1
```
另外我运行这个项目时，IDE的安全插件提示还有8个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p13c3a